### PR TITLE
FIX: Set input font-size to relative value (instead of percentage)

### DIFF
--- a/src/components/GlobalStyle/css-reset.js
+++ b/src/components/GlobalStyle/css-reset.js
@@ -257,7 +257,7 @@ export const cssReset = css`
   input,
   select,
   textarea {
-    font-size: 100%; /* 1 */
+    font-size: 16px; /* 1 */
     margin: 0; /* 2 */
     vertical-align: baseline; /* 3 */
     *vertical-align: middle; /* 3 */


### PR DESCRIPTION
This _might_ fix the bug where iOS decides to zoom into the page when tapping on the input.
